### PR TITLE
Add obs-vkcapture source support.

### DIFF
--- a/adv-ff.py
+++ b/adv-ff.py
@@ -136,6 +136,10 @@ source_fetch_proc = {"game_capture" :                 {"get_hooked":[("string", 
                                                                      ("bool",     "hooked"),
                                                                      ],
                                                        },
+                     "vkcapture-source":              {"get_hooked":[("string",   "executable"),
+                                                                     ("bool",     "hooked"),
+                                                                     ],
+                                                       },
                      }
 
 calldata_fetchers = {"string":  obs.calldata_string,

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -58,6 +58,9 @@ Additionally, the following keys are added for use alongside the source settings
     - `class`: class of the window currently hooked (empty string if the source is not hooked)
 - For Text sources (both Freetype2 and GDI+):
     - `file_text`: if the source is reading from file, the contents of the file in question, otherwise an empty string
+- For obs-vkcapture sources (require version 1.5.6 and up):
+    - `hooked`: whether the source is currently hooked to a window
+    - `executable`: executable of the window currently hooked (empty string if the source is not hooked)
 
 [^2]: Builtin, not win-capture-audio plugin.
 


### PR DESCRIPTION
obs-vkcapture 1.5.6 added get_hooked support.

https://github.com/nowrep/obs-vkcapture/pull/287

It's only support `hooked` and `executable`