### PR TITLE
RFC: Add Flatpak extension build script for pyparsing, and use the path if available.

### DIFF
--- a/adv-ff.py
+++ b/adv-ff.py
@@ -50,7 +50,10 @@ if sys.version_info[0] < 3 or sys.version_info[1] < 9:
 
 print(f"adv-ff starting load of version {('.').join((str(n) for _, n in version.items()))} on python {sys.version}")
 
-
+flatpak_runtime="/app/plugins/adv-ff/lib/python%d.%d/site-packages"%sys.version_info[0:2]
+if os.path.exists(flatpak_runtime) and os.path.isdir(flatpak_runtime):
+    sys.path.append(flatpak_runtime)
+    print("Found python runtime for flatpak in %s"%flatpak_runtime)
 
 try:
     pyp_version = meta.version("pyparsing")

--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,0 +1,5 @@
+*.flatpak
+.flatpak-builder/
+_build/
+python3-requirements.json
+repo/

--- a/flatpak/com.obsproject.Studio.Plugin.adv-ff.json
+++ b/flatpak/com.obsproject.Studio.Plugin.adv-ff.json
@@ -1,0 +1,26 @@
+{
+  "id": "com.obsproject.Studio.Plugin.adv-ff",
+  "branch": "stable",
+  "runtime": "com.obsproject.Studio",
+  "runtime-version": "stable",
+  "sdk": "org.freedesktop.Sdk//25.08",
+  "build-extension": true,
+  "separate-locales": false,
+  "appstream-compose": false,
+  "modules": [
+    "python3-requirements.json",
+    {
+      "name": "adv-ff",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm755 adv-ff.py ${FLATPAK_DEST}/app/bin/adv-ff.py"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "../adv-ff.py"
+        }
+      ]
+    }
+  ]
+}

--- a/flatpak/flatpak_build.sh
+++ b/flatpak/flatpak_build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+cd "$(dirname "$0")" || {
+    echo "Cannot access $(dirname "$0")" >&2
+    exit 1
+}
+
+declare repo_name=adv-ff \
+    repo=repo \
+    manifest=com.obsproject.Studio.Plugin.adv-ff.json \
+    python_requirements=requirements.txt \
+    bundle_name=com.obsproject.Studio.Plugin.adv-ff.flatpak
+
+declare exe missing_exe
+for exe in flatpak-builder flatpak_pip_generator jq; do
+    command -v "$exe" >/dev/null 2>&1 || {
+        echo "Missing $exe" >&2
+        missing_exe=1
+    }
+done
+[ "$missing_exe" ] && exit 2
+unset exe missing_exe
+
+if [ ! -r "$manifest" ]; then
+    echo "manifest $manifest is missing or unreadable"
+    exit 3
+fi
+
+declare app_id sdk branch
+if ! {
+    app_id=$(jq -r '.id' "$manifest") &&
+    sdk=$(jq -r '.sdk' "$manifest") &&
+    branch=$(jq -r '.branch' "$manifest")
+}; then
+    echo "Error occurred when reading $manifest"
+    exit 4
+fi
+
+flatpak_pip_generator --runtime "$sdk" -r "$python_requirements"
+
+if ! {
+    flatpak-builder --force-clean --install-deps-from=flathub --repo="$repo" _build "$manifest" &&
+    flatpak build-bundle --runtime "$repo" "$bundle_name" "$app_id" "$branch"
+}; then
+    exit $?
+fi
+
+printf -- '\n%s\n' "Do you want to install $app_id?: (y/N)"
+declare line
+read -r line
+[ ! "${line@L}" = y ] && exit 0
+unset line
+
+flatpak --user install "$bundle_name"

--- a/flatpak/requirements.txt
+++ b/flatpak/requirements.txt
@@ -1,0 +1,1 @@
+pyparsing


### PR DESCRIPTION
Instead of manually hoping the system python version match runtime and manually copying the module.

I suggest building a extension for obs and modify adv-ff script to use that.

The build script need flatpak, flatpak-builder, flatpak_pip_generator and jq.

Instead of modifying the script.

Adding env `PYTHONUSERBASE=/app/plugins/adv-ff` with 

```
flatpak override --user --env=PYTHONUSERBASE=/app/plugins/adv-ff com.obsproject.Studio
```

is also a option.